### PR TITLE
Implement back-end logic for club approval flow

### DIFF
--- a/clubs/admin.py
+++ b/clubs/admin.py
@@ -6,6 +6,6 @@ import teach.admin as teach_admin
 
 class ClubAdmin(admin.ModelAdmin):
     list_display = ('name', 'location', 'created', 'modified', 'owner',
-                    'is_active')
+                    'status', 'is_active')
 
 teach_admin.site.register(models.Club, ClubAdmin)

--- a/clubs/email.py
+++ b/clubs/email.py
@@ -24,6 +24,7 @@ Name: %(club_name)s
 Location: %(club_location)s
 Website: %(club_website)s
 Description: %(club_description)s
+Email: %(email)s
 
 This club is currently in a pending state and you can approve or deny it
 for inclusion in the public map at:

--- a/clubs/email.py
+++ b/clubs/email.py
@@ -15,15 +15,20 @@ on behalf of the Mozilla Learning team
 P.S. Be sure to check out our tips for running clubs at %(TEACH_SITE_URL)s/clubs/ !
 """
 
-CREATE_MAIL_STAFF_SUBJECT = 'A new Club has been added to the map'
+CREATE_MAIL_STAFF_SUBJECT = 'Please review: new club has been submitted'
 
 CREATE_MAIL_STAFF_BODY = """\
-%(username)s has added their Club to the map.
+%(username)s would like to add their Club to the map.
 
 Name: %(club_name)s
 Location: %(club_location)s
 Website: %(club_website)s
 Description: %(club_description)s
 
-You may want to email them at %(email)s to say hello!
+This club is currently in a pending state and you can approve or deny it
+for inclusion in the public map at:
+
+%(admin_url)s
+
+You may also want to email them at %(email)s to say hello!
 """

--- a/clubs/migrations/0006_club_status.py
+++ b/clubs/migrations/0006_club_status.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs', '0005_auto_20150325_1912'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='club',
+            name='status',
+            field=models.CharField(default=b'approved', help_text=b'Current approval status of the club.', max_length=10, choices=[(b'pending', b'Pending'), (b'approved', b'Approved'), (b'denied', b'Denied')]),
+            preserve_default=True,
+        ),
+    ]

--- a/clubs/models.py
+++ b/clubs/models.py
@@ -3,6 +3,15 @@ from django.contrib.auth.models import User
 from geopy.geocoders import Nominatim
 
 class Club(models.Model):
+    PENDING = 'pending'
+    APPROVED = 'approved'
+    DENIED = 'denied'
+    STATUS_CHOICES = (
+        (PENDING, 'Pending'),
+        (APPROVED, 'Approved'),
+        (DENIED, 'Denied')
+    )
+
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
@@ -42,6 +51,13 @@ class Club(models.Model):
                    "Leave blank to automatically determine."),
         blank=True,
         null=True
+    )
+
+    status = models.CharField(
+        help_text="Current approval status of the club.",
+        max_length=10,
+        choices=STATUS_CHOICES,
+        default=APPROVED
     )
 
     is_active = models.BooleanField(

--- a/clubs/tests/test_views.py
+++ b/clubs/tests/test_views.py
@@ -20,7 +20,8 @@ class ClubViewSetTests(TestCase):
             description='This is my club.',
             location='Somewhere',
             latitude=5,
-            longitude=6
+            longitude=6,
+            status='approved'
         )
         club.save()
         self.club = club
@@ -36,7 +37,8 @@ class ClubViewSetTests(TestCase):
             'description': 'This is my club.',
             'location': 'Somewhere',
             'latitude': 5,
-            'longitude': 6
+            'longitude': 6,
+            'status': 'approved'
         }])
 
     def create_club(self):
@@ -49,6 +51,30 @@ class ClubViewSetTests(TestCase):
             'latitude': 1,
             'longitude': 2
         })
+
+    def test_create_clubs_sets_status_to_pending(self):
+        response = self.create_club()
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data['status'], 'pending')
+
+    def test_update_clubs_changes_status_from_denied_to_pending(self):
+        self.club.status = 'denied'
+        self.club.save()
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.patch('/api/clubs/1/', {'description': 'u'})
+        self.assertEqual(response.data['status'], 'pending')
+
+    def test_update_clubs_does_not_change_status_if_already_approved(self):
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.patch('/api/clubs/1/', {'description': 'u'})
+        self.assertEqual(response.data['status'], 'approved')
+
+    def test_update_clubs_does_not_change_status_if_already_pending(self):
+        self.club.status = 'pending'
+        self.club.save()
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.patch('/api/clubs/1/', {'description': 'u'})
+        self.assertEqual(response.data['status'], 'pending')
 
     def test_create_clubs_sets_owner(self):
         response = self.create_club()

--- a/clubs/tests/test_views.py
+++ b/clubs/tests/test_views.py
@@ -89,12 +89,14 @@ class ClubViewSetTests(TestCase):
         self.assertEqual(msg.to, ['user2@example.org'])
         self.assertRegexpMatches(msg.body, 'user2')
 
-    @override_settings(TEACH_STAFF_EMAILS=['foo@bar.org'])
+    @override_settings(TEACH_STAFF_EMAILS=['foo@bar.org'],
+                       ORIGIN='https://s')
     def test_create_clubs_sends_email_to_teach_staff(self):
         response = self.create_club()
         msg = mail.outbox[1]
         self.assertEqual(msg.to, ['foo@bar.org'])
         self.assertRegexpMatches(msg.body, 'user2@example.org')
+        self.assertRegexpMatches(msg.body, 'https://s/admin/clubs/club/2/')
 
     def test_list_clubs_only_shows_active_clubs(self):
         self.club.is_active = False

--- a/clubs/tests/test_views.py
+++ b/clubs/tests/test_views.py
@@ -103,6 +103,29 @@ class ClubViewSetTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, [])
 
+    def test_list_clubs_only_shows_approved_clubs_for_anonymous_users(self):
+        self.club.status = 'pending'
+        self.club.save()
+        response = self.client.get('/api/clubs/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
+    def test_list_clubs_hides_non_approved_clubs_of_other_users(self):
+        self.club.status = 'pending'
+        self.club.save()
+        self.client.force_authenticate(user=self.user2)
+        response = self.client.get('/api/clubs/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])
+
+    def test_list_clubs_shows_non_approved_clubs_of_logged_in_user(self):
+        self.club.status = 'pending'
+        self.club.save()
+        self.client.force_authenticate(user=self.user1)
+        response = self.client.get('/api/clubs/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
     def test_patch_clubs_without_auth_fails(self):
         response = self.client.patch('/api/clubs/1/', {'name': 'u'})
         self.assertEqual(response.status_code, 403)

--- a/clubs/views.py
+++ b/clubs/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from django.conf import settings
 from django.core.mail import send_mail
 from rest_framework import serializers, viewsets, permissions
@@ -44,6 +45,12 @@ class ClubViewSet(viewsets.ModelViewSet):
     serializer_class = ClubSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,
                           IsOwnerOrReadOnly,)
+
+    def get_queryset(self):
+        q = Q(status=Club.APPROVED)
+        if self.request.user.is_authenticated():
+            q = q | Q(owner=self.request.user)
+        return self.queryset.filter(q)
 
     def perform_create(self, serializer):
         club = serializer.save(

--- a/clubs/views.py
+++ b/clubs/views.py
@@ -1,4 +1,5 @@
 from django.db.models import Q
+from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.core.mail import send_mail
 from rest_framework import serializers, viewsets, permissions
@@ -77,7 +78,11 @@ class ClubViewSet(viewsets.ModelViewSet):
                     'club_name': club.name,
                     'club_location': club.location,
                     'club_website': club.website,
-                    'club_description': club.description
+                    'club_description': club.description,
+                    'admin_url': '%s%s' % (
+                        settings.ORIGIN,
+                        reverse('admin:clubs_club_change', args=(club.id,))
+                    )
                 },
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=settings.TEACH_STAFF_EMAILS,

--- a/clubs/views.py
+++ b/clubs/views.py
@@ -40,6 +40,21 @@ class ClubViewSet(viewsets.ModelViewSet):
     authentication. The user who created a club is its **owner** and
     they are the only one who can make future edits to it, aside
     from staff.
+
+    Clubs also have an approval flow they must proceed through. The
+    state of this approval is reflected in the club's **status**.
+
+    When a club is first created through the REST API, its status is
+    set to `"pending"` and Teach staff are alerted through email.
+
+    Depending on the result of review, the state may later be modified
+    by Teach staff to `"approved"` or `"denied"`.
+
+    If a club's status is pending or denied, only the club's owner
+    can view it.
+
+    If a club's status is denied and its owner updates any of the
+    club's metadata, the status is changed to pending.
     """
 
     queryset = Club.objects.filter(is_active=True)


### PR DESCRIPTION
This implements the server-side requirements for https://github.com/mozilla/teach.webmaker.org/issues/921.

Still to do:
- [x] Update the REST API docs to document the approval flow a bit.
- [x] Email subject when clubs are added should be changed - https://github.com/mozilla/teach.webmaker.org/issues/922
