### PR TITLE
[WIP] Add Discourse SSO endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ variables are given default values: `SECRET_KEY`, `PORT`, `ORIGIN`.
 * `TEACH_SITE_URL` is the URL to the Teach site, used when sending
   emails to users, among other things. It defaults to
   https://teach.mozilla.org.
+* `DISCOURSE_SSO_SECRET` is the SSO secret for Discourse single sign-on.
+  For more information, see [discourse_sso/README.md][]. If empty or
+  undefined, Discourse SSO functionality will be disabled.
+* `DISCOURSE_SSO_ORIGIN` is the origin of your Discourse site. If
+  `DISCOURSE_SSO_SECRET` is set, this must also be set.
 
 ### Deprecated Environment Variables
 
@@ -117,3 +122,4 @@ production over http.**
   [teach]: https://github.com/mozilla/teach.webmaker.org
   [twelve-factor]: http://12factor.net/
   [djrill]: https://github.com/brack3t/Djrill
+  [discourse_sso/README.md]: https://github.com/mozilla/teach-api/tree/master/discourse_sso#readme

--- a/discourse_sso/README.md
+++ b/discourse_sso/README.md
@@ -1,0 +1,26 @@
+The `discourse_sso` Dajngo app provides a [Discourse SSO][sso] endpoint 
+for the site, allowing users to login with their Webmaker credentials
+and use the same username that they have on the site.
+
+To enable Discourse SSO on your site, ensure the following Django settings
+are configured:
+
+* `DISCOURSE_SSO_SECRET` is the secret shared between your site
+  and the Discourse site.
+* `DISCOURSE_SSO_ORIGIN` is the origin of your Discourse site, e.g.
+  `http://my-discourse.org`.
+
+On the Discourse side, you'll want to make sure the following are
+configured under "Settings > Users" in Discourse's admin panel:
+
+* "sso secret" should be identical to `DISCOURSE_SSO_SECRET`.
+* "enable sso" should be checked.
+* "sso url" should be set to the origin of your site, followed
+  by `/discourse_sso/`. For example, `http://example.org/discourse_sso/`.
+* You'll also probably want to check some of the checkboxes for SSO
+  overrides, so that user information on your Discourse always
+  reflects the state of your site as closely as possible.
+
+<!-- Links -->
+
+  [sso]: https://meta.discourse.org/t/official-single-sign-on-for-discourse/13045

--- a/discourse_sso/README.md
+++ b/discourse_sso/README.md
@@ -1,17 +1,18 @@
 The `discourse_sso` Dajngo app provides a [Discourse SSO][sso] endpoint 
-for the site, allowing users to login with their Webmaker credentials
-and use the same username that they have on the site.
+for the Django site, allowing users to login to Discourse with their
+Webmaker credentials and use the same username that they have
+on Webmaker.
 
-To enable Discourse SSO on your site, ensure the following Django settings
+To enable Discourse SSO, ensure the following Django settings
 are configured:
 
-* `DISCOURSE_SSO_SECRET` is the secret shared between your site
-  and the Discourse site.
+* `DISCOURSE_SSO_SECRET` is the secret shared between your Django
+  site and the Discourse site.
 * `DISCOURSE_SSO_ORIGIN` is the origin of your Discourse site, e.g.
   `http://my-discourse.org`.
 
 On the Discourse side, you'll want to make sure the following are
-configured under "Settings > Users" in Discourse's admin panel:
+configured under "Settings > Login" in Discourse's admin panel:
 
 * "sso secret" should be identical to `DISCOURSE_SSO_SECRET`.
 * "enable sso" should be checked.
@@ -19,7 +20,8 @@ configured under "Settings > Users" in Discourse's admin panel:
   by `/discourse_sso/`. For example, `http://example.org/discourse_sso/`.
 * You'll also probably want to check some of the checkboxes for SSO
   overrides, so that user information on your Discourse always
-  reflects the state of your site as closely as possible.
+  reflects the state of the user's Webmaker account as closely as
+  possible.
 
 <!-- Links -->
 

--- a/discourse_sso/admin.py
+++ b/discourse_sso/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/discourse_sso/models.py
+++ b/discourse_sso/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/discourse_sso/tests.py
+++ b/discourse_sso/tests.py
@@ -1,0 +1,42 @@
+import urlparse
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.contrib.auth.models import User
+
+from .views import pack_and_sign_payload, unpack_and_verify_payload
+
+@override_settings(DISCOURSE_SSO_SECRET='test',
+                   DISCOURSE_SSO_ORIGIN='http://discourse.org')
+class EndpointTests(TestCase):
+    def login(self):
+        self.user = User.objects.create_user('foo', 'foo@example.org', 'pass')
+        self.assertTrue(self.client.login(username='foo',
+                                          password='pass'))
+
+    def test_invalid_payloads_are_rejected(self):
+        self.login()
+        payload = pack_and_sign_payload({'nonce': '1'}, secret='INVALID')
+        response = self.client.get('/discourse_sso/', payload)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_members_are_redirected_to_discourse(self):
+        self.login()
+        payload = pack_and_sign_payload({'nonce': '1'})
+        response = self.client.get('/discourse_sso/', payload)
+
+        self.assertEqual(response.status_code, 302)
+
+        loc = urlparse.urlparse(response['location'])
+        self.assertEqual(loc.scheme, 'http')
+        self.assertEqual(loc.netloc, 'discourse.org')
+        self.assertEqual(loc.path, '/session/sso_login')
+
+        query_dict = dict(urlparse.parse_qsl(loc.query))
+        self.assertEqual(unpack_and_verify_payload(query_dict), {
+            'email': 'foo@example.org',
+            'external_id': str(self.user.id),
+            'name': 'foo',
+            'nonce': '1',
+            'username': 'foo'
+        })

--- a/discourse_sso/tests.py
+++ b/discourse_sso/tests.py
@@ -35,6 +35,7 @@ class EndpointTests(TestCase):
         query_dict = dict(urlparse.parse_qsl(loc.query))
         self.assertEqual(unpack_and_verify_payload(query_dict), {
             'email': 'foo@example.org',
+            'require_activation': 'true',
             'external_id': str(self.user.id),
             'name': 'foo',
             'nonce': '1',

--- a/discourse_sso/urls.py
+++ b/discourse_sso/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import patterns, include, url
+
+from . import views
+
+urlpatterns = patterns('',
+    url(r'^$', views.sso_endpoint)
+)

--- a/discourse_sso/views.py
+++ b/discourse_sso/views.py
@@ -1,0 +1,68 @@
+import base64
+import urlparse
+import hmac
+import urllib
+from hashlib import sha256
+from django.conf import settings
+from django.http import HttpResponseRedirect, HttpResponseBadRequest
+from django.shortcuts import render
+from django.contrib.auth.decorators import user_passes_test
+
+if hasattr(hmac, 'compare_digest'):
+    compare_digest = hmac.compare_digest
+else:
+    # Slightly modified from http://stackoverflow.com/a/18173992.
+    def compare_digest(x, y):
+        if not (isinstance(x, bytes) and isinstance(y, bytes)):
+            raise TypeError("both inputs should be instances of bytes")
+        if len(x) != len(y):
+            return False
+        result = 0
+        for a, b in zip(x, y):
+            result |= ord(a) ^ ord(b)
+        return result == 0
+
+def hmac_sign(payload, secret=None):
+    if secret is None: secret = settings.DISCOURSE_SSO_SECRET
+    return hmac.new(secret, payload, sha256)
+
+def unpack_and_verify_payload(query_dict):
+    payload = query_dict['sso']
+    their_sig = query_dict['sig'].decode('hex')
+    our_sig = hmac_sign(payload).digest()
+
+    if not compare_digest(our_sig, their_sig):
+        raise Exception('invalid signature')
+
+    return dict(urlparse.parse_qsl(base64.b64decode(payload)))
+
+def pack_and_sign_payload(payload_dict, secret=None):
+    payload = base64.b64encode(urllib.urlencode(payload_dict))
+    return {
+        'sso': payload,
+        'sig': hmac_sign(payload, secret).hexdigest()
+    }
+
+def user_info_qs(user, nonce):
+    user_name = user.get_full_name() or user.username
+    return urllib.urlencode(pack_and_sign_payload({
+        'nonce': nonce,
+        'email': str(user.email),
+        'external_id': str(user.id),
+        'username': str(user.username),
+        'name': user_name.encode('utf8')
+    }))
+
+def sso_endpoint(request):
+    # TODO: Make the user log in if they aren't already.
+    try:
+        nonce = unpack_and_verify_payload(request.GET)['nonce']
+    except Exception:
+        return HttpResponseBadRequest()
+
+    url = '%s/session/sso_login?%s' % (
+        settings.DISCOURSE_SSO_ORIGIN,
+        user_info_qs(request.user, nonce)
+    )
+
+    return HttpResponseRedirect(url)

--- a/discourse_sso/views.py
+++ b/discourse_sso/views.py
@@ -47,6 +47,7 @@ def user_info_qs(user, nonce):
     user_name = user.get_full_name() or user.username
     return urllib.urlencode(pack_and_sign_payload({
         'nonce': nonce,
+        'require_activation': 'true',
         'email': str(user.email),
         'external_id': str(user.id),
         'username': str(user.username),

--- a/discourse_sso/views.py
+++ b/discourse_sso/views.py
@@ -6,7 +6,7 @@ from hashlib import sha256
 from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import render
-from django.contrib.auth.decorators import user_passes_test
+from django.contrib.auth.decorators import login_required
 
 if hasattr(hmac, 'compare_digest'):
     compare_digest = hmac.compare_digest
@@ -53,8 +53,8 @@ def user_info_qs(user, nonce):
         'name': user_name.encode('utf8')
     }))
 
+@login_required
 def sso_endpoint(request):
-    # TODO: Make the user log in if they aren't already.
     try:
         nonce = unpack_and_verify_payload(request.GET)['nonce']
     except Exception:

--- a/teach/settings.py
+++ b/teach/settings.py
@@ -243,6 +243,8 @@ CORS_API_LOGIN_ORIGINS = os.environ.get(
     ''
 ).split(',')
 
+LOGIN_URL = 'teach.views.oauth2_authorize'
+
 if is_running_test_suite():
     PASSWORD_HASHERS = (
         'django.contrib.auth.hashers.MD5PasswordHasher',

--- a/teach/settings.py
+++ b/teach/settings.py
@@ -44,6 +44,9 @@ LOGINAPI_AUTH = os.environ.get('LOGINAPI_AUTH')
 TEACH_SITE_URL = os.environ.get('TEACH_SITE_URL',
                                 'https://teach.mozilla.org')
 
+DISCOURSE_SSO_SECRET = os.environ.get('DISCOURSE_SSO_SECRET')
+DISCOURSE_SSO_ORIGIN = os.environ.get('DISCOURSE_SSO_ORIGIN')
+
 if 'ADMIN_PROTECTION_USERPASS' in os.environ:
     ADMIN_PROTECTION_USERPASS = os.environ['ADMIN_PROTECTION_USERPASS']
 
@@ -110,6 +113,9 @@ if IDAPI_ENABLE_FAKE_OAUTH2:
     INSTALLED_APPS += (
         'fake_oauth2',
     )
+
+if DISCOURSE_SSO_SECRET or is_running_test_suite():
+    INSTALLED_APPS += ('discourse_sso',)
 
 MIDDLEWARE_CLASSES = ()
 

--- a/teach/tests/test_views.py
+++ b/teach/tests/test_views.py
@@ -189,6 +189,18 @@ class OAuth2EndpointTests(TestCase):
         self.client.get('/auth/oauth2/authorize')
         self.assertEqual(self.client.session['oauth2_state'], 'abcd')
 
+    @override_settings(ORIGIN='http://teach')
+    def test_authorize_remembers_valid_next(self):
+        qs = urllib.urlencode({'next': '/boop'})
+        response = self.client.get('/auth/oauth2/authorize?%s' % qs)
+        self.assertEqual(self.client.session['oauth2_callback'],
+                         'http://teach/boop')
+
+    def test_authorize_ignores_invalid_next(self):
+        qs = urllib.urlencode({'next': 'http://evil.com/bad'})
+        response = self.client.get('/auth/oauth2/authorize?%s' % qs)
+        self.assertFalse('oauth2_callback' in self.client.session)
+
     def test_authorize_remembers_valid_callback(self):
         qs = urllib.urlencode({'callback': 'http://frontend/blah'})
         response = self.client.get('/auth/oauth2/authorize?%s' % qs)

--- a/teach/urls.py
+++ b/teach/urls.py
@@ -45,3 +45,8 @@ if settings.IDAPI_ENABLE_FAKE_OAUTH2:
     urlpatterns += [
         url(r'^fake_oauth2/', include('fake_oauth2.urls')),
     ]
+
+if 'discourse_sso' in settings.INSTALLED_APPS:
+    urlpatterns += [
+        url(r'^discourse_sso/', include('discourse_sso.urls'))
+    ]

--- a/teach/views.py
+++ b/teach/views.py
@@ -56,6 +56,10 @@ def validate_callback(callback):
 
 def set_callback(request):
     callback = validate_callback(request.GET.get('callback', ''))
+    if (not callback
+        and 'next' in request.GET
+        and request.GET['next'].startswith('/')):
+        callback = settings.ORIGIN + request.GET['next']
     if callback:
         request.session['oauth2_callback'] = callback
 


### PR DESCRIPTION
This adds a [Discourse SSO](https://meta.discourse.org/t/official-single-sign-on-for-discourse/13045) endpoint to teach-api, to support the migration to Discourse SSO discussed at https://github.com/mozilla/teach.webmaker.org/issues/930.

Most of this code is taken from [hive-django's `discourse_sso` app](https://github.com/toolness/hive-django/tree/master/discourse_sso).

Still to do:

- [x] Direct unauthenticated users to login via id.webmaker.org.
