### PR TITLE
post hook for running migration on deploy

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Init the DB.
+python manage.py initdb
+
+# Run Django migrations.
+python manage.py migrate


### PR DESCRIPTION
based on https://discussion.heroku.com/t/django-automaticlly-run-syncdb-and-migrations-after-heroku-deploy-with-a-buildpack-or-otherwise/466/7 this should allow heroku to run migrations as part of the deploy