### PR TITLE
Add urls, views and serializers for clubs guides

### DIFF
--- a/clubs_guides/models.py
+++ b/clubs_guides/models.py
@@ -1,22 +1,36 @@
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
-@python_2_unicode_compatible
+class CategoryQuerySet(models.query.QuerySet):
+    """
+    A custom queryset class for Category
+    """
+    def collate_clubs_guides(self):
+        return self.prefetch_related(
+            models.Prefetch(
+                "clubs_guides",
+                queryset=ClubsGuide.objects.filter(
+                    translation_of__isnull=True
+                )
+            )
+        )
+
+
 class Category(models.Model):
     """
     Category a Mozilla Club's resource guide belongs to
     """
     name = models.CharField(max_length=200)
 
+    objects = CategoryQuerySet.as_manager()
+
     class Meta:
         verbose_name_plural = "categories"
 
-    def __str__(self):
-        return self.name
+    def __unicode__(self):
+        return unicode(self.name)
 
 
-@python_2_unicode_compatible
 class ClubsGuide(models.Model):
     """
     Resource guides for Mozilla Clubs
@@ -50,5 +64,5 @@ class ClubsGuide(models.Model):
         null=True,
     )
 
-    def __str__(self):
-        return self.title
+    def __unicode__(self):
+        return unicode(self.title)

--- a/clubs_guides/serializers.py
+++ b/clubs_guides/serializers.py
@@ -1,3 +1,66 @@
 from rest_framework import serializers
 
-# Add your serializers here.
+from clubs_guides.models import ClubsGuide, Category
+
+
+class ClubsGuideBaseSerializer(serializers.ModelSerializer):
+    """
+    Serializes a clubs guide with only the basic information
+    directly relevant to a clubs guide
+    """
+    class Meta:
+        model = ClubsGuide
+        fields = ("title", "url", "language",)
+
+
+class ClubsGuideSerializer(ClubsGuideBaseSerializer):
+    """
+    Serializes a clubs guide
+    """
+    category = serializers.StringRelatedField()
+    translation_of = serializers.StringRelatedField()
+
+    class Meta(ClubsGuideBaseSerializer.Meta):
+        fields = (
+            ClubsGuideBaseSerializer.Meta.fields +
+            ("category", "translation_of",)
+        )
+
+
+class ClubsGuideWithTranslationsSerializer(ClubsGuideBaseSerializer):
+    """
+    Serializes a clubs guide and also includes other related clubs
+    guides that are direct translations of it
+    """
+    translations = ClubsGuideBaseSerializer(many=True)
+
+    class Meta(ClubsGuideBaseSerializer.Meta):
+        fields = (
+            ClubsGuideBaseSerializer.Meta.fields +
+            ("translations",)
+        )
+
+
+class CategorySerializer(serializers.ModelSerializer):
+    """
+    Serializes a clubs guide category
+    """
+    class Meta:
+        model = Category
+        fields = ("name",)
+
+
+class CategoryWithClubsGuideSerializer(serializers.ModelSerializer):
+    """
+    Serializes a clubs guide category and includes the clubs guides
+    associated with that category
+    """
+    category = serializers.CharField(source="name")
+    guides = ClubsGuideWithTranslationsSerializer(
+        source="clubs_guides",
+        many=True,
+    )
+
+    class Meta:
+        model = Category
+        fields = ("category", "guides",)

--- a/clubs_guides/tests.py
+++ b/clubs_guides/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/clubs_guides/tests/test_factory.py
+++ b/clubs_guides/tests/test_factory.py
@@ -1,0 +1,18 @@
+from factory import Factory, Faker, LazyAttribute
+
+from clubs_guides.models import ClubsGuide, Category
+
+
+class ClubsGuideFactory(Factory):
+    title = LazyAttribute(lambda o: ' '.join(Faker("words", nb=4).generate({})))
+    url = Faker("url")
+
+    class Meta:
+        model = ClubsGuide
+
+
+class CategoryFactory(Factory):
+    name = LazyAttribute(lambda o: ' '.join(Faker("words", nb=4).generate({})))
+
+    class Meta:
+        model = Category

--- a/clubs_guides/tests/test_models.py
+++ b/clubs_guides/tests/test_models.py
@@ -1,0 +1,43 @@
+from factory import Faker
+from django.test import TestCase
+
+from clubs_guides.tests.test_factory import ClubsGuideFactory, CategoryFactory
+from clubs_guides.models import Category
+
+
+class TestCategoryListView(TestCase):
+    def setUp(self):
+        self.categories = []
+        for i in range(2):
+            self.categories.append(CategoryFactory())
+            self.categories[i].save()
+
+        self.clubs_guides = []
+        for i in range(3):
+            guide = ClubsGuideFactory()
+            guide.category = self.categories[i % 2]
+            guide.save()
+            self.clubs_guides.append(guide)
+
+        self.fr_clubs_guide = ClubsGuideFactory(
+            title=' '.join(Faker("words", locale="fr_FR", nb=4).generate({})),
+            category=self.clubs_guides[0].category,
+            translation_of=self.clubs_guides[0],
+            language=u'Fran\xe7ais',
+        )
+        self.fr_clubs_guide.save()
+
+    def test_queryset_collate_clubs_guides(self):
+        """
+        Test if the `collate_clubs_guides` filter on the queryset
+        returns only the untranslated clubs guides for each category
+        """
+        result = Category.objects.collate_clubs_guides()
+
+        self.assertEqual(len(self.categories), len(result))
+
+        for category in self.categories:
+            self.assertIn(category, result)
+
+        for category in result:
+            self.assertNotIn(self.fr_clubs_guide, category.clubs_guides.all())

--- a/clubs_guides/tests/test_models.py
+++ b/clubs_guides/tests/test_models.py
@@ -15,15 +15,16 @@ class TestCategoryListView(TestCase):
         self.clubs_guides = []
         for i in range(3):
             guide = ClubsGuideFactory()
+            # Assign categories alternately to the list of clubs guides
             guide.category = self.categories[i % 2]
             guide.save()
             self.clubs_guides.append(guide)
 
         self.fr_clubs_guide = ClubsGuideFactory(
-            title=' '.join(Faker("words", locale="fr_FR", nb=4).generate({})),
+            title=" ".join(Faker("words", locale="fr_FR", nb=4).generate({})),
             category=self.clubs_guides[0].category,
             translation_of=self.clubs_guides[0],
-            language=u'Fran\xe7ais',
+            language=u"Fran\xe7ais",
         )
         self.fr_clubs_guide.save()
 

--- a/clubs_guides/urls.py
+++ b/clubs_guides/urls.py
@@ -14,8 +14,10 @@ urlpatterns = [
     # `/` - Gets a list of clubs guides
     url("^$", ClubsGuidesListView.as_view(), name="clubsguide-list"),
 
-    # `/:pk` - Gets a single clubs guide by its primary key (the named group is
-    # called pk by default in Django) viz. `id`
+    # `/:pk` - Gets a single clubs guide by its primary key, where the named
+    # group is called pk by default in Django, (see
+    # https://docs.djangoproject.com/en/1.10/topics/class-based-views/generic-display/#performing-extra-work)
+    # but represents the clubs guide's `id`
     url(r"^(?P<pk>[0-9]+)", ClubsGuideView.as_view(), name="clubsguide"),
 
     # `/categories` - Gets a list of clubs guide categories which may also

--- a/clubs_guides/urls.py
+++ b/clubs_guides/urls.py
@@ -1,3 +1,18 @@
 from django.conf.urls import url
 
-# Create you url mappings here.
+from clubs_guides.views import (
+    ClubsGuidesListView,
+    ClubsGuideView,
+    CategoryListView,
+)
+
+
+urlpatterns = [
+    url("^$", ClubsGuidesListView.as_view(), name="clubsguide-list"),
+    url(r"^(?P<pk>[0-9]+)", ClubsGuideView.as_view(), name="clubsguide"),
+    url(
+        "^categories",
+        CategoryListView.as_view(),
+        name="clubsguide-category-list"
+    ),
+]

--- a/clubs_guides/urls.py
+++ b/clubs_guides/urls.py
@@ -7,14 +7,15 @@ from clubs_guides.views import (
 )
 
 
-# Root URL: `/clubsguides` (this can be changed in the teach/urls.py file)
+# Root URL: `/api/clubsguides` (this can be changed in the teach/urls.py file)
 # NOTE: The patterns below are tacked onto the root url mentioned above
 
 urlpatterns = [
     # `/` - Gets a list of clubs guides
     url("^$", ClubsGuidesListView.as_view(), name="clubsguide-list"),
 
-    # `/:pk` - Gets a single clubs guide by its primary key viz. `id`
+    # `/:pk` - Gets a single clubs guide by its primary key (the named group is
+    # called pk by default in Django) viz. `id`
     url(r"^(?P<pk>[0-9]+)", ClubsGuideView.as_view(), name="clubsguide"),
 
     # `/categories` - Gets a list of clubs guide categories which may also

--- a/clubs_guides/urls.py
+++ b/clubs_guides/urls.py
@@ -7,9 +7,19 @@ from clubs_guides.views import (
 )
 
 
+# Root URL: `/clubsguides` (this can be changed in the teach/urls.py file)
+# NOTE: The patterns below are tacked onto the root url mentioned above
+
 urlpatterns = [
+    # `/` - Gets a list of clubs guides
     url("^$", ClubsGuidesListView.as_view(), name="clubsguide-list"),
+
+    # `/:pk` - Gets a single clubs guide by its primary key viz. `id`
     url(r"^(?P<pk>[0-9]+)", ClubsGuideView.as_view(), name="clubsguide"),
+
+    # `/categories` - Gets a list of clubs guide categories which may also
+    #       contain all the clubs guides associated with them depending on the
+    #       query string value passed in.
     url(
         "^categories",
         CategoryListView.as_view(),

--- a/clubs_guides/views.py
+++ b/clubs_guides/views.py
@@ -1,3 +1,73 @@
-from django.shortcuts import render
+from rest_framework.generics import ListAPIView, RetrieveAPIView
 
-# Create your views here.
+from clubs_guides.models import ClubsGuide, Category
+from clubs_guides.serializers import (
+    ClubsGuideSerializer,
+    CategorySerializer,
+    CategoryWithClubsGuideSerializer,
+)
+
+
+class ClubsGuidesListView(ListAPIView):
+    """
+    A view that permits a GET to allow listing all the clubs guides
+    in the database
+
+    **Route** - `/clubsguides`
+
+    """
+    queryset = ClubsGuide.objects.all()
+    serializer_class = ClubsGuideSerializer
+
+
+class ClubsGuideView(RetrieveAPIView):
+    """
+    A view that permits a GET to allow listing of a single clubs guide
+    by providing its id.
+
+    **Route** - `/clubsguides/:id`
+
+    """
+    queryset = ClubsGuide.objects.all()
+    serializer_class = ClubsGuideSerializer
+
+
+class CategoryListView(ListAPIView):
+    """
+    A view that permits a GET to allow listing all the clubs guides
+    in the database
+
+    **Route** - `/clubsguides/categories`
+
+    **Query Parameters** -
+
+    - `?expand=` - Expand related entities instead of
+                   passing in just their foreign keys
+
+        The only currently supported value is `?expand=clubsguides`
+    """
+    def get_queryset(self):
+        if self.is_expand_clubs_guides():
+            return Category.objects.collate_clubs_guides()
+
+        return Category.objects.all()
+
+    def get_serializer_class(self):
+        if self.is_expand_clubs_guides():
+            return CategoryWithClubsGuideSerializer
+        else:
+            return CategorySerializer
+
+    def is_expand_clubs_guides(self):
+        if hasattr(self, "expand_clubs_guides"):
+            return self.expand_clubs_guides
+
+        expand = self.request.query_params.get("expand")
+        if expand is not None:
+            expand = expand.split(',')
+        else:
+            expand = []
+
+        self.expand_clubs_guides = "clubsguides" in expand
+
+        return self.expand_clubs_guides

--- a/clubs_guides/views.py
+++ b/clubs_guides/views.py
@@ -12,9 +12,6 @@ class ClubsGuidesListView(ListAPIView):
     """
     A view that permits a GET to allow listing all the clubs guides
     in the database
-
-    **Route** - `/clubsguides`
-
     """
     queryset = ClubsGuide.objects.all()
     serializer_class = ClubsGuideSerializer
@@ -24,9 +21,6 @@ class ClubsGuideView(RetrieveAPIView):
     """
     A view that permits a GET to allow listing of a single clubs guide
     by providing its id.
-
-    **Route** - `/clubsguides/:id`
-
     """
     queryset = ClubsGuide.objects.all()
     serializer_class = ClubsGuideSerializer
@@ -36,8 +30,6 @@ class CategoryListView(ListAPIView):
     """
     A view that permits a GET to allow listing all the clubs guides
     in the database
-
-    **Route** - `/clubsguides/categories`
 
     **Query Parameters** -
 
@@ -58,6 +50,8 @@ class CategoryListView(ListAPIView):
         else:
             return CategorySerializer
 
+    # Check if the request asks to embed full representations of the clubs
+    # guides that belong to each category
     def is_expand_clubs_guides(self):
         if hasattr(self, "expand_clubs_guides"):
             return self.expand_clubs_guides

--- a/requirements.minimal.txt
+++ b/requirements.minimal.txt
@@ -6,7 +6,7 @@ wsgiref==0.1.2
 dj-database-url==0.2.2
 django-browserid==0.11.1
 requests==2.5.3
-djangorestframework==3.1.0
+djangorestframework==3.1.2
 geopy==1.9.1
 django-cors-headers==1.0.0
 django-csp==2.0.3
@@ -16,3 +16,4 @@ slumber==0.7.1
 # For tests to run...
 mock==1.0.1
 httmock==1.2.2
+factory_boy==2.7.0

--- a/teach/urls.py
+++ b/teach/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     url(r'^admin/', include(teach_admin.urls)),
 
     url(r'^credly/', include('credly.urls')),
-    url(r'^clubsguides/', include('clubs_guides.urls')),
+    url(r'^api/clubsguides/', include('clubs_guides.urls')),
 ]
 
 if settings.IDAPI_ENABLE_FAKE_OAUTH2:

--- a/teach/urls.py
+++ b/teach/urls.py
@@ -27,7 +27,8 @@ urlpatterns = [
     url(r'', include('django_browserid.urls')),
     url(r'^admin/', include(teach_admin.urls)),
 
-    url(r'^credly/', include('credly.urls'))
+    url(r'^credly/', include('credly.urls')),
+    url(r'^clubsguides/', include('clubs_guides.urls')),
 ]
 
 if settings.IDAPI_ENABLE_FAKE_OAUTH2:


### PR DESCRIPTION
This patch:
- Adds the url config to access `/api/clubsguides`, `/api/clubsguides/:id`, `/api/clubsguides/categories`, `/api/clubsguides/categories?expand=clubsguides` (the last one is the one I think we will be using)
  - Also adds the main `/api/clubsguides` root url to the teach-api url config
- Adds the views that host logic for the above urls
- Adds the serializers used in the views above
- Tests custom logic (the queryset modification for categories)