### PR TITLE
Allow filtering club guides in admin interface

### DIFF
--- a/clubs_guides/admin.py
+++ b/clubs_guides/admin.py
@@ -7,6 +7,7 @@ from clubs_guides.forms import ClubsGuideForm
 @admin.register(ClubsGuide)
 class ClubsGuideAdmin(admin.ModelAdmin):
     form = ClubsGuideForm
+    list_filter = ("category__name", "language",)
 
     def get_form(self, request, obj=None, **kwargs):
         kwargs["form"] = ClubsGuideForm

--- a/clubs_guides/migrations/0004_auto_20160915_1857.py
+++ b/clubs_guides/migrations/0004_auto_20160915_1857.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('clubs_guides', '0003_auto_20160811_1606'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='category',
+            name='name',
+            field=models.CharField(max_length=200, verbose_name=b'category name'),
+            preserve_default=True,
+        ),
+    ]

--- a/clubs_guides/models.py
+++ b/clubs_guides/models.py
@@ -20,7 +20,10 @@ class Category(models.Model):
     """
     Category a Mozilla Club's resource guide belongs to
     """
-    name = models.CharField(max_length=200)
+    name = models.CharField(
+        max_length=200,
+        verbose_name='category name',
+    )
 
     objects = CategoryQuerySet.as_manager()
 


### PR DESCRIPTION
This allows filtering club guides by their category and/or by their language as per the requirement in https://github.com/mozilla/teach-api/issues/68#issuecomment-247367328